### PR TITLE
Added user delete functionality

### DIFF
--- a/lib/keycloak/api/user_resources.rb
+++ b/lib/keycloak/api/user_resources.rb
@@ -69,6 +69,11 @@ module Keycloak
           JSON.parse(get(url, params: params)).map { |user| Model::UserRepresentation.new(user) }
         end
       end
+
+      # @param id [String] user id
+      def delete_user(id)
+        delete("#{user_resources_url}/#{id}", headers: {content_type: :json})
+      end
     end
   end
 end

--- a/lib/keycloak/version.rb
+++ b/lib/keycloak/version.rb
@@ -1,3 +1,3 @@
 module Keycloak
-  VERSION = "0.0.19"
+  VERSION = "0.0.20"
 end


### PR DESCRIPTION
Added user delete functionality so I can clean up a Keycloak instance where I accidentally disconnected the users from their LDAP backend storage. Bumped the version, not sure if that's needed.